### PR TITLE
Validate server addresses

### DIFF
--- a/src/cli/new.rs
+++ b/src/cli/new.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use std::fs;
+use std::net::IpAddr;
 
 use crate::{
     cli::prompt_for_confirmation,
@@ -53,8 +54,8 @@ impl NewCommand {
         route.add_response(response);
         route.set_active_response(resp_id);
 
-        let mut serverinfo = ServerInfo::new();
-        serverinfo.server.address.clone_from(&self.address);
+        let mut serverinfo = ServerInfo::new()?;
+        serverinfo.server.address = self.address.parse::<IpAddr>()?;
         serverinfo.server.port = self.port;
         serverinfo.server.name.clone_from(&self.name);
         serverinfo.server.description = "".into();

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1,4 +1,8 @@
-use serde::{Deserialize, Serialize};
+use anyhow::Result;
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt;
+use std::net::IpAddr;
 use uuid::Uuid;
 
 use super::Header;
@@ -8,7 +12,8 @@ pub struct Server {
     pub id: Uuid,
     #[serde(rename = "routerId")]
     pub router_id: Uuid,
-    pub address: String,
+    #[serde(deserialize_with = "deserialize_ipaddr")]
+    pub address: IpAddr,
     pub port: u16,
     pub name: String,
     pub description: String,
@@ -17,16 +22,18 @@ pub struct Server {
 
 impl Server {
     #[allow(dead_code)]
-    pub fn new(router_id: Uuid, address: &str, port: u16) -> Self {
-        Server {
+    pub fn new(router_id: Uuid, address: &str, port: u16) -> Result<Self> {
+        let address = address.parse::<IpAddr>()?;
+
+        Ok(Server {
             id: Uuid::new_v4(),
             router_id,
-            address: address.to_string(),
+            address,
             port,
             name: String::default(),
             description: String::default(),
             headers: vec![],
-        }
+        })
     }
 
     #[allow(dead_code)]
@@ -46,6 +53,31 @@ impl Server {
         self.headers.push(header);
         self
     }
+}
+
+// Custom deserialization function for IpAddr
+fn deserialize_ipaddr<'de, D>(deserializer: D) -> Result<IpAddr, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct IpAddrVisitor;
+
+    impl<'de> Visitor<'de> for IpAddrVisitor {
+        type Value = IpAddr;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a valid IPv4 or IPv6 address")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<IpAddr, E>
+        where
+            E: de::Error,
+        {
+            value.parse().map_err(de::Error::custom)
+        }
+    }
+
+    deserializer.deserialize_str(IpAddrVisitor)
 }
 
 #[cfg(test)]
@@ -76,7 +108,7 @@ mod tests {
 
         let server: Server = serde_json::from_str(json).expect("Unable to parse JSON.");
         assert_eq!(server.id, uuid!("a3c6bf8d-57ab-4693-94dd-4d3a47dd1403"));
-        assert_eq!(server.address, "127.0.0.1");
+        assert_eq!(server.address.to_string(), "127.0.0.1");
         assert_eq!(server.port, 8080);
         assert_eq!(server.name, "Unit Test");
         assert_eq!(server.headers.len(), 1);
@@ -89,5 +121,33 @@ mod tests {
             uuid!("d49427b0-8d2f-47cc-a5b4-c3754c53583b")
         );
         assert_eq!(server.description, "Just an example of a server in JSON.");
+    }
+
+    #[test]
+    fn cannot_use_invalid_ip_address() {
+        let server = Server::new(Uuid::new_v4(), "invalid.ip.addr", 0);
+        assert!(server.is_err());
+
+        let json = r###"
+        {
+            "id": "a3c6bf8d-57ab-4693-94dd-4d3a47dd1403",
+            "address": "invalid.ip.addr",
+            "port": 8080,
+            "name": "Unit Test",
+            "headers": [
+                {
+                    "id": "5ea28783-d770-4754-98e9-749aab005511",
+                    "key": "Content-Type",
+                    "value": "application/html",
+                    "active": true
+                }
+            ],
+            "routerId": "d49427b0-8d2f-47cc-a5b4-c3754c53583b",
+            "description": "Just an example of a server in JSON."
+        }
+        "###;
+
+        let server = serde_json::from_str::<Server>(json);
+        assert!(server.is_err());
     }
 }

--- a/src/http/serverinfo.rs
+++ b/src/http/serverinfo.rs
@@ -1,9 +1,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::{
-    fs::File,
-    io::{Read, Write},
-};
+use std::fs::File;
+use std::io::{Read, Write};
 
 use super::{Router, Server};
 
@@ -16,19 +14,13 @@ pub struct ServerInfo {
     pub router: Router,
 }
 
-impl Default for ServerInfo {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ServerInfo {
-    pub fn new() -> Self {
+    pub fn new() -> Result<Self> {
         let mut router = Router::new(None);
-        let server = Server::new(router.id, DEFAULT_SERVER_ADDR, DEFAULT_SERVER_PORT);
+        let server = Server::new(router.id, DEFAULT_SERVER_ADDR, DEFAULT_SERVER_PORT)?;
         router.bind_server(&server);
 
-        Self { server, router }
+        Ok(Self { server, router })
     }
 
     pub fn from_file(file_path: &str) -> Result<Self> {
@@ -95,7 +87,7 @@ mod tests {
         route.add_response(response);
         route.set_active_response(resp_id);
 
-        let mut serverinfo = ServerInfo::new();
+        let mut serverinfo = ServerInfo::new().unwrap();
         serverinfo.server.name = "server name".to_string();
         serverinfo.server.description = "description".to_string();
         serverinfo.router.add_route(route);

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -10,7 +10,7 @@ pub struct TestApp {
 
 fn make_serverinfo() -> ServerInfo {
     let mut router = Router::new(None);
-    let server = Server::new(router.id, "127.0.0.1", 0); // addr here is disregarded
+    let server = Server::new(router.id, "127.0.0.1", 0).unwrap(); // addr here is disregarded
     router.bind_server(&server);
 
     ServerInfo { server, router }


### PR DESCRIPTION
Covers `new()`-ing a Server and deserializing from JSON. Since the `new` sub-command also uses `Server::new()`, the command will also display an error if you try to use an invalid address.