### PR TITLE
Structured logging using `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,29 +570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +688,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -842,12 +829,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1088,6 +1069,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1126,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,13 +1175,15 @@ dependencies = [
  "anyhow",
  "clap",
  "dotenv",
- "env_logger",
  "fs2",
  "log",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-bunyan-formatter",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -1204,6 +1202,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1280,6 +1288,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1431,8 +1445,17 @@ checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1443,7 +1466,7 @@ checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1451,6 +1474,12 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1649,6 +1678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +1802,16 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1895,7 +1943,37 @@ checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "tracing-bunyan-formatter"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c266b9ac83dedf0e0385ad78514949e6d89491269e7065bee51d2bb8ec7373"
+dependencies = [
+ "ahash",
+ "gethostname",
+ "log",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.1.4",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1905,6 +1983,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]
@@ -1963,6 +2082,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,14 @@ actix-web = "4.5.1"
 anyhow = "1.0.86"
 clap = { version = "4.5.4", features = ["derive"] }
 dotenv = "0.15.0"
-env_logger = "0.11.3"
 fs2 = "0.4.3"
 log = "0.4.21"
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = "1.0.116"
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }
+tracing = { version = "0.1.40", features = ["log"] }
+tracing-bunyan-formatter = "0.3.9"
+tracing-subscriber = { version = "0.3.18", features = ["registry", "env-filter"] }
 uuid = { version = "1.8.0", features = ["v4", "serde"] }
 
 [dev-dependencies]

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -117,7 +117,8 @@ fn make_route_handler(server_headers: Arc<Vec<Header>>, route: &Route) -> Option
 
         async move {
             let mut resp = HttpResponse::build(StatusCode::from_u16(status).unwrap());
-            debug!("Responding with {status}");
+            let body_len = body.len();
+            debug!("Responding with status code {status}, body {body_len} bytes");
 
             for header in headers {
                 resp.append_header((header.key.clone(), header.value.clone()));


### PR DESCRIPTION
Example output:
```
{"v":0,"name":"mockerize-cli","msg":"Registering route GET /api/v1/lists","level":30,"hostname":"Quartz","pid":31024,"time":"2024-06-26T16:03:50.9268923Z","target":"mockerize_cli::startup","line":19,"file":"src\\startup.rs"}
{"v":0,"name":"mockerize-cli","msg":"Registering route POST /api/v1/lists","level":30,"hostname":"Quartz","pid":31024,"time":"2024-06-26T16:03:50.9270939Z","target":"mockerize_cli::startup","line":19,"file":"src\\startup.rs"}
{"v":0,"name":"mockerize-cli","msg":"Registering route DELETE /api/v1/lists/:item-id","level":30,"hostname":"Quartz","pid":31024,"time":"2024-06-26T16:03:50.9272342Z","target":"mockerize_cli::startup","line":19,"file":"src\\startup.rs"}
{"v":0,"name":"mockerize-cli","msg":"Registering route PUT /api/v1/lists/:list-id","level":30,"hostname":"Quartz","pid":31024,"time":"2024-06-26T16:03:50.9273761Z","target":"mockerize_cli::startup","line":19,"file":"src\\startup.rs"}
{"v":0,"name":"mockerize-cli","msg":"starting 32 workers","level":30,"hostname":"Quartz","pid":31024,"time":"2024-06-26T16:03:50.9276401Z","target":"actix_server::builder","line":272,"file":"C:\\Users\\admin\\.cargo\\registry\\src\\index.crates.io-6f17d22bba15001f\\actix-server-2.4.0\\src\\builder.rs"}
{"v":0,"name":"mockerize-cli","msg":"Tokio runtime found; starting in existing Tokio runtime","level":30,"hostname":"Quartz","pid":31024,"time":"2024-06-26T16:03:50.9278703Z","target":"actix_server::server","line":197,"file":"C:\\Users\\admin\\.cargo\\registry\\src\\index.crates.io-6f17d22bba15001f\\actix-server-2.4.0\\src\\server.rs"}
{"v":0,"name":"mockerize-cli","msg":"[CLIENT REQUESTED MOCK ENDPOINT - START]","level":30,"hostname":"Quartz","pid":31024,"time":"2024-06-26T16:03:51.6430815Z","target":"mockerize_cli::startup","line":107,"file":"src\\startup.rs","path":"/api/v1/lists","request_id":"6011cb33-d3d1-456c-8da8-e7809a0b6522","method":"GET","response_id":"438f8657-9468-485f-ba2a-20d5b356da5a"}
{"v":0,"name":"mockerize-cli","msg":"[HANDLING RESPONSE - START]","level":30,"hostname":"Quartz","pid":31024,"time":"2024-06-26T16:03:51.6433301Z","target":"mockerize_cli::startup","line":116,"file":"src\\startup.rs","path":"/api/v1/lists","request_id":"6011cb33-d3d1-456c-8da8-e7809a0b6522","method":"GET","response_id":"438f8657-9468-485f-ba2a-20d5b356da5a"}
{"v":0,"name":"mockerize-cli","msg":"[HANDLING RESPONSE - EVENT] Responding with 200","level":20,"hostname":"Quartz","pid":31024,"time":"2024-06-26T16:03:51.6435428Z","target":"mockerize_cli::startup","line":120,"file":"src\\startup.rs","path":"/api/v1/lists","request_id":"6011cb33-d3d1-456c-8da8-e7809a0b6522","method":"GET","response_id":"438f8657-9468-485f-ba2a-20d5b356da5a"}
{"v":0,"name":"mockerize-cli","msg":"[HANDLING RESPONSE - END]","level":30,"hostname":"Quartz","pid":31024,"time":"2024-06-26T16:03:51.6437506Z","target":"mockerize_cli::startup","line":116,"file":"src\\startup.rs","path":"/api/v1/lists","request_id":"6011cb33-d3d1-456c-8da8-e7809a0b6522","method":"GET","elapsed_milliseconds":0,"response_id":"438f8657-9468-485f-ba2a-20d5b356da5a"}
{"v":0,"name":"mockerize-cli","msg":"[CLIENT REQUESTED MOCK ENDPOINT - END]","level":30,"hostname":"Quartz","pid":31024,"time":"2024-06-26T16:03:51.6439332Z","target":"mockerize_cli::startup","line":107,"file":"src\\startup.rs","path":"/api/v1/lists","request_id":"6011cb33-d3d1-456c-8da8-e7809a0b6522","method":"GET","elapsed_milliseconds":0,"response_id":"438f8657-9468-485f-ba2a-20d5b356da5a"}
```